### PR TITLE
Migrate from JUnit 4 to JUnit 5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,13 @@ publishPlugin {
 }
 
 dependencies {
-    testImplementation 'junit:junit:4.13.2'
+    testImplementation platform('org.junit:junit-bom:5.11.4')
+    testImplementation 'org.junit.jupiter:junit-jupiter'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+test {
+    useJUnitPlatform()
 }
 
 tasks.withType(JavaCompile) {


### PR DESCRIPTION
## Summary
- JUnit 4.13.2 → JUnit Jupiter 5.11.4 (BOM管理)
- `useJUnitPlatform()` を有効化

テストソースは現在存在しないため、依存関係の入れ替えのみです。

## Test plan
- [ ] CI が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)