### PR TITLE
Upgrade to Gradle 9.4.1 and IntelliJ Platform Plugin 2.5.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,38 +1,46 @@
 plugins {
     id 'java'
-    id 'org.jetbrains.intellij' version '1.17.4'
+    id 'org.jetbrains.intellij.platform'
 }
 
 group = 'me.geso.assertj_postfix_plugin'
 version = '0.0.4'
 
-sourceCompatibility = 17
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
 
 repositories {
     mavenCentral()
-}
-
-intellij {
-    version = '2024.1'
-    plugins = ['com.intellij.java']
-    updateSinceUntilBuild = false
-}
-
-tasks {
-    patchPluginXml {
-        sinceBuild = '241'
+    intellijPlatform {
+        defaultRepositories()
     }
 }
 
-// Write `intellijPublishToken=YOUR_HUB_TOKEN_HERE` in your gradle.properties.
-publishPlugin {
-    token = providers.gradleProperty('intellijPublishToken')
-}
-
 dependencies {
+    intellijPlatform {
+        intellijIdeaCommunity('2024.1')
+        bundledPlugin('com.intellij.java')
+        pluginVerifier()
+        instrumentationTools()
+    }
     testImplementation platform('org.junit:junit-bom:5.11.4')
     testImplementation 'org.junit.jupiter:junit-jupiter'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+intellijPlatform {
+    pluginConfiguration {
+        ideaVersion {
+            sinceBuild = '241'
+        }
+    }
+    buildSearchableOptions = false
+    // Write `intellijPublishToken=YOUR_HUB_TOKEN_HERE` in your gradle.properties.
+    publishing {
+        token = providers.gradleProperty('intellijPublishToken')
+    }
 }
 
 test {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,4 +5,8 @@ pluginManagement {
     }
 }
 
+plugins {
+    id 'org.jetbrains.intellij.platform.settings' version '2.5.0'
+}
+
 rootProject.name = 'assertj-postfix-plugin'


### PR DESCRIPTION
## Summary
- Gradle wrapper 8.12 → 9.4.1
- `org.jetbrains.intellij` 1.17.4 → `org.jetbrains.intellij.platform` 2.5.0 に移行（Gradle 9非対応のため）
- `sourceCompatibility` を `java` ブロック内に移動（Gradle 9で必須）

## Test plan
- [ ] CI が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)